### PR TITLE
Add option to only test servers running from ram or disk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Mullvad Ping
 
-Gets the list of Mullvad servers with the best latency according to `ping`. 
+Gets the list of Mullvad servers with the best latency according to `ping`.
 
-Run 
+Run
 
 ```bash
 deno run --allow-net --allow-run https://raw.githubusercontent.com/grant0417/mullvad-ping/main/script.ts

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage: script [OPTION]
     --count <n>         the number of pings to the server (default 3)
     --interval <i>      the interval between pings in seconds (default/min 0.2)
     --top <n>           the number of top servers to show, (0=all)
-    --port-speed <n>    only show servers with at least n Gigabit port speed             
+    --port-speed <n>    only show servers with at least n Gigabit port speed
+    --run-mode <type>   only show servers running from (all, ram, disk)
     --help              usage information
 ```

--- a/script.ts
+++ b/script.ts
@@ -21,7 +21,7 @@ function sleep(ms: number) {
 }
 
 function checkRunMode(stboot: boolean, runMode: string) {
-  if(runMode == "all") {
+  if (runMode == "all") {
     return true;
   } else if (runMode == "ram" && stboot == true) {
     return true;
@@ -73,7 +73,7 @@ const portSpeed = parseInt(args["port-speed"] ?? 0) || 0;
 
 const runMode = args["run-mode"] ?? "all";
 if (!runTypes.includes(runMode)) {
-  console.error(`Invalid running-from, allowed types are: ${runTypes.join(", ")}`);
+  console.error(`Invalid run-mode, allowed types are: ${runTypes.join(", ")}`);
   Deno.exit(1);
 }
 

--- a/script.ts
+++ b/script.ts
@@ -12,6 +12,7 @@ type ServerDataJSON = {
   ipv4_addr_in: string;
   ipv6_addr_in: string;
   network_port_speed: number;
+  stboot: boolean;
   type: string;
 };
 
@@ -19,7 +20,19 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function checkRunMode(stboot: boolean, runMode: string) {
+  if(runMode == "all") {
+    return true;
+  } else if (runMode == "ram" && stboot == true) {
+    return true;
+  } else if (runMode == "disk" && stboot == false) {
+    return true;
+  }
+  return false;
+}
+
 const serverTypes = ["openvpn", "bridge", "wireguard", "all"];
+const runTypes = ["all", "ram", "disk"];
 
 const args = parse(Deno.args);
 if (args.help == true) {
@@ -35,7 +48,8 @@ if (args.help == true) {
   }
   console.log(
     `    --top <n>           the number of top servers to show, (0=all)
-    --port-speed <n>    only show servers with at least n Gigabit port speed             
+    --port-speed <n>    only show servers with at least n Gigabit port speed
+    --run-mode <type>   only show servers running from (${runTypes.join(", ")})
     --help              usage information`,
   );
   Deno.exit(0);
@@ -57,6 +71,12 @@ const count = parseInt(args.count ?? 5) || 5;
 const topN = parseInt(args.top ?? 5) || 5;
 const portSpeed = parseInt(args["port-speed"] ?? 0) || 0;
 
+const runMode = args["run-mode"] ?? "all";
+if (!runTypes.includes(runMode)) {
+  console.error(`Invalid running-from, allowed types are: ${runTypes.join(", ")}`);
+  Deno.exit(1);
+}
+
 console.log("Fetching currently avaiable relays...");
 const response = await fetch(
   `https://api.mullvad.net/www/relays/${serverType}/`,
@@ -77,7 +97,8 @@ if (args["list-countries"]) {
   for (const server of json) {
     if (
       (country == null || country == server.country_code) &&
-      server.network_port_speed >= portSpeed
+      (server.network_port_speed >= portSpeed) &&
+      checkRunMode(server.stboot, runMode)
     ) {
       let cmd = [];
       if (Deno.build.os == "windows") {


### PR DESCRIPTION
Mullvad is beginning to move their servers to ram and have added ram/disk filters to their server list.
https://mullvad.net/en/blog/2022/8/1/expanding-diskless-infrastructure-to-more-locations-system-transparency-stboot/

This adds a new flag that allows testing only servers running from ram, disk, or all servers.